### PR TITLE
Update ember-data to v.1.0.0-beta.16.1

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -23,19 +23,21 @@ export default DS.Adapter.extend({
     ];
   },
 
-  createRecord(store, type, record) {
+  createRecord(store, type, snapshot) {
     // rather then doing an ajax, just echo back the data that was created
+    var record = snapshot.record;
     var json = record.toJSON();
 
-    // assign a unique ID like the server word
+    // assign a unique ID like the server would
     json.id = Date.now();
 
     // return a value or a promise
     return json;
   },
 
-  updateRecord(store, type, record) {
+  updateRecord(store, type, snapshot) {
     // rather then doing an ajax, just echo back the data that was updated
+    var record = snapshot.record;
     var json = record.toJSON();
 
     json.id = record.id;
@@ -43,7 +45,9 @@ export default DS.Adapter.extend({
     return json;
   },
 
-  deleteRecord(store, type, record) {
+  deleteRecord(store, type, snapshot) {
+    var record = snapshot.record;
+
     return { id: record.id };
   }
 });

--- a/app/components/todos-list/template.hbs
+++ b/app/components/todos-list/template.hbs
@@ -1,4 +1,3 @@
 {{#each todos as |todo|}}
   {{todo-item todo=todo}}
 {{/each}}
-

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "jquery": "^1.11.1",
     "ember": "1.10.0",
-    "ember-data": "1.0.0-beta.15",
+    "ember-data": "1.0.0-beta.16.1",
     "ember-resolver": "~0.1.12",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.9",
     "ember-cli-uglify": "1.0.1",
-    "ember-data": "1.0.0-beta.15",
+    "ember-data": "1.0.0-beta.16.1",
     "ember-export-application-global": "^1.0.2",
     "express": "^4.8.5",
     "glob": "^4.0.5"


### PR DESCRIPTION
- Updates ember-data to v.1.0.0-beta.16.1
- Updates the `ApplicationAdapter` to work with snapshots vs. records being passed in directly
