### PR TITLE
Update to latest ember stable - Lets bring in Glimmer

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,6 +1,10 @@
 import DS from 'ember-data';
 
 export default DS.Adapter.extend({
+  shouldReloadAll() {
+    //silence ember-data deprecation
+    return true;
+  },
   findAll() {
     // rather then doing an ajax, just echo back the default data
 

--- a/app/application/route.js
+++ b/app/application/route.js
@@ -7,7 +7,7 @@ export default Ember.Route.extend({
   },
 
   model(params) {
-    return this.store.find('todo').then((todos) => {
+    return this.store.findAll('todo').then((todos) => {
       return {
         all: todos,
         filter: params.state

--- a/app/components/todos-route/template.hbs
+++ b/app/components/todos-route/template.hbs
@@ -5,7 +5,7 @@
             class='new-todo'
             placeholder='What needs to be done?'
             value=newTitle
-            action='createTodo'}}
+            enter='createTodo'}}
   </header>
 
   <section class='main'>

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
   "name": "todos",
   "dependencies": {
-    "ember": "1.12.1",
+    "ember": "1.13.2",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.0.0-beta.19",
+    "ember-data": "1.13.1",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "todos",
-  "version": "0.0.0",
-  "description": "Small description for todos goes here",
+  "version": "1.13.0",
+  "description": "This is an example of the todo-mvc app, it aims to trail ember-cli and ember.js's latest stable conventions.",
   "private": true,
   "directories": {
     "doc": "doc",
@@ -12,7 +12,7 @@
     "build": "ember build",
     "test": "ember test"
   },
-  "repository": "",
+  "repository": "https://github.com/ember-cli/ember-cli-todos.git",
   "engines": {
     "node": ">= 0.10.0"
   },
@@ -30,7 +30,7 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.13",
     "ember-cli-uglify": "^1.0.1",
-    "ember-data": "^1.0.0-beta.19",
+    "ember-data": "^1.13.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2"
   }

--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -26,7 +26,7 @@ test('#model state:all', function(assert) {
 
   var route = this.subject({
     store: {
-      find(type) {
+      findAll(type) {
         assert.equal(type, 'todo');
 
         return Ember.RSVP.Promise.resolve(expectedModel);


### PR DESCRIPTION
I upgraded to the latest ember stable and equivalent ember-data, fixed deprecations and tests.

I also versioned it 1.13.0 to be inline with the [suggested versioning strategy](http://emberjs.com/blog/2015/06/16/ember-project-at-2-0.html). Good idea ?
