### PR TITLE
Remove ember-jobs reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Todos
 
-This is an example of the todo-mvc app, it aims to trail ember-cli and ember.js's latest stable conventions. To view a project more on the bleeding edge, feel to pop over and check out [ember-jobs](https://github.com/stefanpenner/ember-jobs)
+This is an example of the todo-mvc app, it aims to trail ember-cli and ember.js's latest stable conventions.
 
 ## Prerequisites
 


### PR DESCRIPTION
If I am not mistaken the last commit to ember-jobs appears to be on April 15. 

Feel free to close if there are plans to reboot ember-jobs back to bleeding edge.
