### PR TITLE
Fixes destructuring issue in todos-route component

### DIFF
--- a/app/components/todos-route/component.js
+++ b/app/components/todos-route/component.js
@@ -3,8 +3,9 @@ import Ember from 'ember';
 const {
   Component,
   isEmpty,
-  computed: { filterBy },
-  inject: { service }
+  computed,
+  computed: {filterBy},
+  inject: {service}
 } = Ember;
 
 export default Component.extend({
@@ -37,7 +38,7 @@ export default Component.extend({
       todos.setEach('isCompleted', value);
       todos.invoke('save');
       return value;
-    } 
+    }
   }),
 
   actions: {


### PR DESCRIPTION
I'm not sure if it is something weird with the way that Babel is transpiling destructuring or what, but this fixes an error in the `todos-route` component.
