### PR TITLE
Save todo item when completion checkbox is changed

### DIFF
--- a/app/components/todo-item/template.hbs
+++ b/app/components/todo-item/template.hbs
@@ -3,7 +3,7 @@
                            focus-out='save'
                            insert-newline='save'}}
 {{else}}
-  {{input type='checkbox' checked=todo.isCompleted class='toggle'}}
+  {{input type='checkbox' checked=todo.isCompleted class='toggle' change=(action 'save') }}
   <label {{action 'editTodo' on='doubleClick'}}>{{todo.title}}</label>
   <button {{action 'removeTodo'}} class='destroy'></button>
 {{/if}}

--- a/tests/integration/components/todo-item-test.js
+++ b/tests/integration/components/todo-item-test.js
@@ -22,7 +22,9 @@ test('completed checkbox triggers a save', function (assert) {
 
   assert.notOk(todo.get('isSaving'), 'todo is not saving before click');
 
-  this.$('input[type=checkbox]').click();
+  Ember.run(() => {
+    this.$('input[type=checkbox]').click();
+  });
 
   assert.ok(todo.get('isCompleted'), 'todo is completed after click');
   assert.ok(todo.get('isSaving'), 'todo is saving after click');

--- a/tests/integration/components/todo-item-test.js
+++ b/tests/integration/components/todo-item-test.js
@@ -1,0 +1,33 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+moduleForComponent('todo-item', 'Integration - Component - Todo Item', {
+  integration: true
+});
+
+test('completed checkbox triggers a save', function (assert) {
+  var store = this.container.lookup('service:store');
+  var todo;
+
+  Ember.run(function () {
+    todo = store.createRecord('todo', {
+      title: 'Confirm save',
+      isCompleted: false
+    });
+  });
+
+  this.set('todo', todo);
+  this.render(hbs`{{todo-item todo=todo}}`);
+
+  assert.notOk(todo.get('isSaving'), 'todo is not saving before click');
+
+  this.$('input[type=checkbox]').click();
+
+  assert.ok(todo.get('isCompleted'), 'todo is completed after click');
+  assert.ok(todo.get('isSaving'), 'todo is saving after click');
+
+  // Return a promise that ensures the test will wait until the todo is saved
+  // before trying to unload it (otherwise an error will be raised):
+  return Ember.run(() => todo.save());
+});


### PR DESCRIPTION
This PR solved the problem described in #17 where the app does not save the model when the completed checkbox is toggled. The lack of saving is only noticable when the app is modified to persist to a store.

I think I've found the simplest possible change to accomplish this - just triggering the `save` action whenever the checkbox changes.
