### PR TITLE
Add momentjs to Bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,7 @@
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
-    "qunit": "~1.18.0"
+    "qunit": "~1.18.0",
+    "moment": "^2.14.1"
   }
 }


### PR DESCRIPTION
When running the app via ember server, Broccoli failed with an `ENOENT` error, complaining that moment/moment.js is missing. I've installed it via a `bower install --save moment` and I managed to get broccoli to build successfully.

This hot fix should add the missing dependency to `bower.json`
